### PR TITLE
Reenable mypy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
           - '3.12'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -27,5 +27,8 @@ jobs:
       - name: Running flake8
         run: flake8 vsdeband
       - name: Running mypy
-        if: steps.dependencies.outcome == 'success'
-        run: mypy vsdeband
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/mypy.json"
+          mypy --no-pretty vsdeband
+          echo "::remove-matcher owner=mypy::"
+        continue-on-error: true

--- a/.github/workflows/matchers/mypy.json
+++ b/.github/workflows/matchers/mypy.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "mypy",
+            "pattern": [
+                {
+                    "regexp": "^(.+):(\\d+):\\s(error|warning|note):\\s(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "severity": 3,
+                    "message": 4
+                }
+            ]
+        }
+    ]
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8>=7.0.0
-mypy>=1.10.0
+mypy>=1.11.2
 mypy-extensions>=1.0.0
 pycodestyle>=2.11.1
-typing-extensions>=4.11.0
+typing-extensions>=4.12.2

--- a/vsdeband/noise.py
+++ b/vsdeband/noise.py
@@ -11,7 +11,7 @@ from vskernels import BicubicAuto, Bilinear, Catrom, Kernel, KernelT, Lanczos, L
 from vsmasktools import adg_mask
 from vsrgtools import BlurMatrix
 from vstools import (
-    CustomIndexError, CustomOverflowError, CustomValueError, InvalidColorFamilyError, KwargsT, Matrix, MatrixT,
+    CustomIndexError, CustomOverflowError, CustomValueError, InvalidColorFamilyError, KwargsT, Matrix, MatrixT, PlanesT,
     check_variable, core, depth, fallback, get_neutral_values, get_peak_value, get_sample_type, get_y, inject_self,
     join, mod_x, normalize_seq, plane, scale_value, split, to_arr, vs
 )
@@ -76,7 +76,7 @@ class GrainPP(_gpp):
 
 
 FadeLimits = tuple[int | Iterable[int] | None, int | Iterable[int] | None]
-GrainPostProcessT = ResolverOneClipArgs | ResolverTwoClipsArgs | str | GrainPP | GrainPP.Resolver
+GrainPostProcessT = type[ResolverOneClipArgs | ResolverTwoClipsArgs | str | GrainPP | GrainPP.Resolver]
 GrainPostProcessesT = GrainPostProcessT | list[GrainPostProcessT]
 
 
@@ -153,7 +153,7 @@ class Grainer(ABC):
             return clip
 
         if strength[0] <= 0.0 and strength[1] > 0.0:
-            planes = [1, 2]
+            planes: PlanesT = [1, 2]
         elif strength[0] > 0.0 and strength[1] <= 0.0:
             planes = 0
         else:
@@ -360,7 +360,7 @@ class AddNoiseBase(Grainer):
         return kwargs
 
     def _is_poisson(self, **kwargs: Any) -> bool:
-        return kwargs.get('type', None) == 4
+        return kwargs.get('type') == 4
 
     def _is_input_dependent(self, clip: vs.VideoNode, **kwargs: Any) -> bool:
         return self._is_poisson(**kwargs)


### PR DESCRIPTION
Mostly wanted to fix `GrainPostProcessT` that was crashing mypy for downstream projects:

    vsdeband/noise.py:79:1: error: Cannot assign multiple types to name "GrainPostProcessT" without an explicit "Type[...]" annotation  [misc]
        GrainPostProcessT = ResolverOneClipArgs | ResolverTwoClipsArgs | str | GrainPP | GrainPP.Resolver
        ^
    vsdeband/noise.py:86: error: INTERNAL ERROR -- Please try using mypy master on GitHub:
    https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
    Please report a bug at https://github.com/python/mypy/issues
    version: 1.11.2
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "mypy/semanal.py", line 7087, in accept
      File "mypy/nodes.py", line 819, in accept
      File "mypy/semanal.py", line 874, in visit_func_def
      File "mypy/semanal.py", line 919, in analyze_func_def
      File "mypy/semanal.py", line 6742, in defer
    AssertionError: Must not defer during final iteration