### PR TITLE
Simplify `GrainPP.Resolver`

### DIFF
--- a/vsdeband/noise.py
+++ b/vsdeband/noise.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import reduce
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Protocol, TypeAlias, cast
+from typing import Any, Callable, Iterable, Protocol, cast
 
 from vsdenoise import Prefilter
 from vsexprtools import complexpr_available, norm_expr
@@ -34,14 +34,6 @@ __all__ = [
 ]
 
 
-class _gpp:
-    if TYPE_CHECKING:
-        from .noise import GrainPP
-        Resolver: TypeAlias = Callable[[vs.VideoNode], GrainPP]
-    else:
-        Resolver: TypeAlias = Callable[[vs.VideoNode], Any]
-
-
 class ResolverOneClipArgs(Protocol):
     def __call__(self, grained: vs.VideoNode) -> vs.VideoNode:
         ...
@@ -53,7 +45,9 @@ class ResolverTwoClipsArgs(Protocol):
 
 
 @dataclass
-class GrainPP(_gpp):
+class GrainPP:
+    Resolver = Callable[[vs.VideoNode], 'GrainPP']
+
     value: str
     kwargs: KwargsT = field(default_factory=lambda: KwargsT())
 
@@ -76,7 +70,7 @@ class GrainPP(_gpp):
 
 
 FadeLimits = tuple[int | Iterable[int] | None, int | Iterable[int] | None]
-GrainPostProcessT = type[ResolverOneClipArgs | ResolverTwoClipsArgs | str | GrainPP | GrainPP.Resolver]
+GrainPostProcessT = ResolverOneClipArgs | ResolverTwoClipsArgs | str | GrainPP | GrainPP.Resolver
 GrainPostProcessesT = GrainPostProcessT | list[GrainPostProcessT]
 
 


### PR DESCRIPTION
griffe (the docs parser used in jet-docs) trips up on the loop of `GrainPP` -> `GrainPP.Resolver` -> `GrainPP` -> `GrainPP.Resolver` -> etc. Because of this the whole `vsdeband.noise` module had to be excluded. While this could be fixed in griffe, it also looked like this could be both fixed and simplified by just quoting the type (like `'GrainPP'`). This way there's no loop and no need for `_gpp`.

Also don't need the the explicit `type` in `GrainPostProcessT` (8550361) anymore.

Verified that the computed type is the same before and after:

    (type) Resolver = (VideoNode) -> GrainPP
    
Total mypy errors: 71 -> 63.

---

P.S. It looks like `GrainPP.Resolver` is not even used anywhere? Maybe `ResolverOneClipArgs` and `ResolverTwoClipsArgs` are supposed to supersede it? Unless I'm missing something, I think we can alternatively just remove `GrainPP.Resolver` and move that alias into `GrainPostProcessT`.